### PR TITLE
Link account fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ docs
 /.project
 .phpunit.*
 /.buildpath
+.scannerwork
+composer.lock
+.rnd
+composer.phar
+response.txt

--- a/README.md
+++ b/README.md
@@ -193,13 +193,27 @@ $account_id = $content->accounts[0]->account_id;    // Optional Account ID to pa
 ```php
 // Load your information
 $userHandle = 'user.silamoney.eth';
-$accountName = 'Custom Account Name';   // Defaults to 'default'
+$accountName = 'Custom Account Name';   // Defaults to 'default' if not provided. (not required)
 $publicToken = 'public-xxx-xxx';        // A temporary token returned from the Plaid Link plugin. See above for testing.
 $accountId = 'string';                  // Recommended but not required. See note above.
 $userPrivateKey = 'some private key';   // The private key used to register the specified user
 
 // Call the api
-$response = $client->linkAccount($userHandle, $accountName, $publicToken, $userPrivateKey, $accountId);
+$response = $client->linkAccount($userHandle, $userPrivateKey, $publicToken, $accountName, $accountId);
+```
+
+**Direct account link method**
+```php
+// Load your information
+$userHandle = 'user.silamoney.eth';
+$accountName = 'Custom Account Name';   // Defaults to 'default' if not provided. (not required)
+$routingNumber = '123456789';           // The routing number. 
+$accountNumber = '123456789012';        // The bank account number
+$userPrivateKey = 'some private key';   // The private key used to register the specified user
+$accountType = 'CHECKING';              // The account type (not required). Only available value is CHECKING
+
+// Call the api
+$response = $client->linkAccountDirect($userHandle, $userPrivateKey, $accountNumber, $routingNumber, $accountName, $accountType);
 ```
 
 ### Success 200

--- a/lib/Domain/LinkAccountMessage.php
+++ b/lib/Domain/LinkAccountMessage.php
@@ -82,13 +82,13 @@ class LinkAccountMessage implements ValidInterface
      */
     public function __construct(
         string $userHandle,
-        string $accountName,
-        string $publicToken,
         string $appHandle,
-        ?string $selectedAccountId,
-        ?string $account_number,
-        ?string $routing_number,
-        ?string $account_type
+        string $accountName = null,
+        string $publicToken = null,
+        ?string $selectedAccountId = null,
+        ?string $account_number = null,
+        ?string $routing_number = null,
+        ?string $account_type = null
     ) {
         $this->publicToken = $publicToken;
         $this->accountName = $accountName;

--- a/lib/Domain/LinkAccountResponse.php
+++ b/lib/Domain/LinkAccountResponse.php
@@ -26,12 +26,56 @@ class LinkAccountResponse
     private $status;
 
     /**
+     * @var string
+     * @Type("string")
+     */
+    private $reference;
+
+    /**
+     * @var string
+     * @Type("string")
+     */
+    private $message;
+
+    /**
+     * @var string
+     * @Type("string")
+     */
+    private $accountName;
+
+    /**
+     * @var float
+     * @Type("float")
+     */
+    private $matchCode;
+
+    /**
      * Gets the response status.
      * @return string
      */
     public function getStatus(): string
     {
         return $this->status;
+    }
+
+    public function getReference(): string 
+    {
+        return $this->reference;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getAccountName(): string
+    {
+        return $this->accountName;
+    }
+
+    public function getMatchCode(): float
+    {
+        return $this->matchCode;
     }
 
     /**

--- a/test/Api/DataProvider/clientException400.json
+++ b/test/Api/DataProvider/clientException400.json
@@ -27,9 +27,8 @@
         "linkAccount",
         [
             "user.silamoney.eth", 
-            "Custom Account Name", 
-            "public-xxx-xxx", 
-            "0CF475AD4A6C4B1E34915A3AF40E62621AC73DD752969473B6B6031A8E03021D"
+            "0CF475AD4A6C4B1E34915A3AF40E62621AC73DD752969473B6B6031A8E03021D",
+            "public-xxx-xxx"
         ]
     ],
     [

--- a/test/Api/DataProvider/clientException401.json
+++ b/test/Api/DataProvider/clientException401.json
@@ -27,9 +27,8 @@
         "linkAccount",
         [
             "user.silamoney.eth", 
-            "Custom Account Name", 
-            "public-xxx-xxx", 
-            "0CF475AD4A6C4B1E34915A3AF40E62621AC73DD752969473B6B6031A8E03021D"
+            "0CF475AD4A6C4B1E34915A3AF40E62621AC73DD752969473B6B6031A8E03021D", 
+            "public-xxx-xxx"
         ]
     ],
     [

--- a/test/Api/GetAccountsTest.php
+++ b/test/Api/GetAccountsTest.php
@@ -74,12 +74,8 @@ class GetAccountsTest extends TestCase
         $my_file = 'response.txt';
         $handle = fopen($my_file, 'r');
         $data = fread($handle, filesize($my_file));
-        // var_dump($data);
         $resp = explode("||", $data);
-        // var_dump($resp[0]);
-        // var_dump($resp[1]);
         $response = self::$api->getAccounts($resp[0], $resp[1]);
-        var_dump($response);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -88,12 +84,8 @@ class GetAccountsTest extends TestCase
         $my_file = 'response.txt';
         $handle = fopen($my_file, 'r');
         $data = fread($handle, filesize($my_file));
-        // var_dump($data);
         $resp = explode("||", $data);
-        // var_dump($resp[0]);
-        // var_dump($resp[1]);
         $response = self::$api->getAccounts(0, 0);
-        // var_dump($response);
         $this->assertEquals(400, $response->getStatusCode());
     }
 
@@ -103,12 +95,8 @@ class GetAccountsTest extends TestCase
         $my_file = 'response.txt';
         $handle = fopen($my_file, 'r');
         $data = fread($handle, filesize($my_file));
-        // var_dump($data);
         $resp = explode("||", $data);
-        // var_dump($resp[0]);
-        // var_dump($resp[1]);
         $response = self::$api->getAccounts($resp[0], 0);
-        // var_dump($response);
         $this->assertEquals(401, $response->getStatusCode());
     }
 }

--- a/test/Api/LinkAccountsTest.php
+++ b/test/Api/LinkAccountsTest.php
@@ -77,26 +77,33 @@ class LinkAccountsTest extends TestCase
         $response = $client->post('/link/item/create', $options);
         $content = json_decode($response->getBody()->getContents());
         $publicToken = $content->public_token;
-        $accountId = $content->accounts[0]->account_id;
 
+        $my_file = 'response.txt';
+        $handle = fopen($my_file, 'r');
+        $data = fread($handle, filesize($my_file));
+        $resp = explode("||", $data);
+        $response = self::$api->linkAccount(
+            $resp[0],
+            $resp[1],
+            $publicToken,
+            null,
+            null
+        );
+        // var_dump($response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertTrue($response->getSuccess());
+    }
+
+    public function testLinkAccountDirect200() {
         $my_file = 'response.txt';
         $handle = fopen($my_file, 'r');
         $data = fread($handle, filesize($my_file));
         // var_dump($data);
         $resp = explode("||", $data);
-        $response = self::$api->linkAccount(
-            $resp[0],
-            'default',
-            $publicToken,
-            $resp[1],
-            $accountId,
-            '123456789012',
-            '123456789',
-            'CHECKING'
-        );
-        // var_dump($response);
+        $response = self::$api->linkAccountDirect($resp[0], $resp[1], '123456789012', '123456789', 'sync_direct');
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertTrue($response->getSuccess());
+        $this->assertStringContainsString('manually linked', $response->getData()->getMessage());
     }
 
     /**
@@ -126,13 +133,8 @@ class LinkAccountsTest extends TestCase
         $resp = explode("||", $data);
         $response = self::$api->linkAccount(
             $resp[0],
-            'Custom Account Name',
-            'public-xxx-xxx',
             $resp[1],
-            '123456789012',
-            '123456789',
-            'CHEKING',
-            'CHECKING'
+            'public-xxx-xxx'
         );
         $this->assertEquals(400, $response->getStatusCode());
     }
@@ -166,13 +168,10 @@ class LinkAccountsTest extends TestCase
         $resp = explode("||", $data);
         $response = self::$api->linkAccount(
             $resp[0],
-            'default',
-            $publicToken,
             $resp[1],
-            $accountId,
-            '123456789012',
-            '123456789',
-            'CHECKING'
+            $publicToken,
+            'default',
+            $accountId
         );
         $this->assertEquals(401, $response->getStatusCode());
     }

--- a/test/Api/SilaBalanceTest.php
+++ b/test/Api/SilaBalanceTest.php
@@ -70,7 +70,6 @@ class SilaBalanceTest extends TestCase
         $handler = HandlerStack::create($mock);
         self::$api->getBalanceClient()->setApiHandler($handler);
         $response = self::$api->silaBalance("address");
-        var_dump($response);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($responseValue, $response->getData());
     }

--- a/test/Api/TransferSilaTest.php
+++ b/test/Api/TransferSilaTest.php
@@ -90,7 +90,6 @@ class TransferSilaTest extends TestCase
             file_put_contents($file, $current);
         }
 
-        var_dump($response);
         $this->assertEquals(200, $response->getStatusCode());
     }
 
@@ -102,7 +101,6 @@ class TransferSilaTest extends TestCase
         $data = fread($handle, filesize($my_file));
         $resp = explode("||", $data);
         $response = self::$api->transferSila(0, 0, 10000, 0, '');
-        // var_dump($response);
         $this->assertEquals(400, $response->getStatusCode());
     }
 
@@ -114,7 +112,6 @@ class TransferSilaTest extends TestCase
         $data = fread($handle, filesize($my_file));
         $resp = explode("||", $data);
         $response = self::$api->transferSila($resp[0], $destination, 10000, $resp[1], '');
-        // var_dump($response);
         $this->assertEquals($response->getStatusCode(), $response->getStatusCode());
     }
 }


### PR DESCRIPTION
1. Broke link account into two methods (token & direct)
2. Fixed current test cases
3. Added a specific test case for direct link account
4. Updated link account documentation
5. Updated .gitignore
6. Removed var_dump from multiple test files.