### PR TITLE
Made client creation documentation more clear. Choose only one method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use Silamoney\Client\Domain\{BalanceEnvironments,Environments};
 $appHandle = 'your app handle';
 $privateKey = 'your private key';
 
-// Create your client
+// Create your client using **ONE** of the following ways:
 $client = new SilaApi('your sila endpoint url', 'your sila balance endpoint url', $appHandle, $privateKey); // From custom URL
 $client = SilaApi::fromEnvironment(Environments::SANDBOX(), BalanceEnvironments::SANDBOX(), $appHandle, $privateKey); // From predefined environments
 $client = SilaApi::fromDefault($appHandle, $privateKey); // From default sandbox environments


### PR DESCRIPTION
I've found that some developers think they need to use all three client creation methods at once. This results in confusion as they move into Production, as the last method overwrites the previous two and always points to the Sandbox.

```.php
// Create your client
$client = new SilaApi('your sila endpoint url', 'your sila balance endpoint url', $appHandle, $privateKey); // From custom URL
$client = SilaApi::fromEnvironment(Environments::SANDBOX(), BalanceEnvironments::SANDBOX(), $appHandle, $privateKey); // From predefined environments
$client = SilaApi::fromDefault($appHandle, $privateKey); // From default sandbox environments
```